### PR TITLE
Added OR condition to get the correct State type value in Item struct

### DIFF
--- a/test/ast-helper.js
+++ b/test/ast-helper.js
@@ -16,7 +16,7 @@ const items = (ca) => {
       name: t.name,
       nodeType: t.nodeType,
       stateVariable: t.stateVariable,
-      type: t.typeName.name,
+      type: t.typeName.name || t.typeName.pathNode.name, 
       mutability: t.typeName.stateMutability,
     }));
 };


### PR DESCRIPTION
* added '|| t.typeName.pathNode.name' to get the correct type name of  the State struct in more recent compiler versions