### PR TITLE
Added uint256 type as valid type for price and sku

### DIFF
--- a/test/supply_chain.test.js
+++ b/test/supply_chain.test.js
@@ -93,8 +93,9 @@ contract("SupplyChain", function (accounts) {
           "Struct Item should have a `sku` member"
         );
         assert(
-          isType(subjectStruct)("sku")("uint"), 
-          "`sku` should be of type `uint`"
+          isType(subjectStruct)("sku")("uint") ||
+            isType(subjectStruct)("sku")("uint256"),
+          "`sku` should be of type `uint256`"
         );
       });
 
@@ -104,8 +105,9 @@ contract("SupplyChain", function (accounts) {
           "Struct Item should have a `price` member"
         );
         assert(
-          isType(subjectStruct)("price")("uint"), 
-          "`price` should be of type `uint`"
+          isType(subjectStruct)("price")("uint") ||
+            isType(subjectStruct)("price")("uint256"), 
+          "`price` should be of type `uint256` "
         );
       });
 


### PR DESCRIPTION
uint is an alias for uint256, and many people use uint256 instead the alias because they prefer uint256 for some cases or for readability.

OpenZeppelin uses uint256 instead of uint:
- ERC20 OpenZeppelin: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol
- ERC721 OpenZeppelin https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol

Example when uint256 could be better:
1. bytes4(keccak('transfer(address, uint)'))
you'll get a different method sig ID than
2. bytes4(keccak('transfer(address, uint256)'))

I thing that an smart contract only understands the second (uint256) case if it is comparing meth. signature Ids

both, uint and uint256 are valids, so I thing both of types should be valid in the test cases